### PR TITLE
Update logger configuration for global_extra fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ logger:
   level:
     base: INFO
     err: WARNING
-  format_str: "[{time:YYYY-MM-DD HH:mm:ss.SSS Z} | {extra[level_short]:<5} | {name}:{line}]: {message}"
+  default_format: "[{time:YYYY-MM-DD HH:mm:ss.SSS Z} | {extra[level_short]:<5} | {name}:{line}]: {message}"
   file:
     logs_dir: "./logs"
     rotate_size: 10000000
@@ -242,9 +242,9 @@ logger:
     include_modules: []
     mute_modules: []
   global_extra:
-    trace_id: "-"
-    request_id: "-"
-    user_id: "-"
+    trace_id: ""
+    request_id: ""
+    user_id: ""
   handlers:
     std_handler:
       enabled: true

--- a/src/beans_logging/config.py
+++ b/src/beans_logging/config.py
@@ -14,7 +14,7 @@ from .constants import (
     DEFAULT_JSON_HANDLER_NAME,
     DEFAULT_ERR_JSON_HANDLER_NAME,
 )
-from .schemas import ExtraBaseModel, LogHandlerPM
+from .schemas import ExtraBaseModel, LogHandlerPM, FormatType
 
 
 def get_default_handlers() -> dict[str, LogHandlerPM]:
@@ -122,16 +122,18 @@ class LoggerConfigPM(ExtraBaseModel):
         default_factory=utils.get_slug_name, min_length=1, max_length=128
     )
     level: LevelConfigPM = Field(default_factory=LevelConfigPM)
-    default_format: str = Field(
-        default="[{time:YYYY-MM-DD HH:mm:ss.SSS Z} | {extra[level_short]:<5} | {name}:{line}]: {message}",
-        min_length=8,
-        max_length=512,
+    default_format: FormatType = Field(
+        default="[{time:YYYY-MM-DD HH:mm:ss.SSS Z} | {extra[level_short]:<5} | {name}:{line}]: {message}"
     )
     file: FileConfigPM = Field(default_factory=FileConfigPM)
     custom_serialize: bool = Field(default=False)
     intercept: InterceptConfigPM = Field(default_factory=InterceptConfigPM)
     global_extra: dict[str, str] = Field(
-        default={"trace_id": "-", "request_id": "-", "user_id": "-"}
+        default={
+            "request_id": "",
+            "trace_id": "",
+            "user_id": "",
+        }
     )
     handlers: dict[str, LogHandlerPM] = Field(default_factory=get_default_handlers)
     extra: ExtraConfigPM | None = Field(default_factory=ExtraConfigPM)

--- a/src/beans_logging/schemas.py
+++ b/src/beans_logging/schemas.py
@@ -52,20 +52,47 @@ _SinkType = Union[
     Handler,
 ]
 
+FormatType = Union[
+    str, Callable[["Record"], str], Callable[[dict[str, Any]], str], None
+]
+
+_FilterType = Union[
+    Callable[["Record"], bool],
+    Callable[[dict[str, Any]], bool],
+    str,
+    dict[str, Any],
+    None,
+]
+
+_RotationType = Union[
+    str,
+    int,
+    datetime.time,
+    datetime.timedelta,
+    Callable[["Message", TextIO], bool],
+    Callable[[str, TextIO], bool],
+    Callable[[str, Any], bool],
+    None,
+]
+
+_RetentionType = Union[
+    str,
+    int,
+    datetime.timedelta,
+    Callable[[Any], None],
+    None,
+]
+
 
 class LoguruHandlerPM(ExtraBaseModel):
     sink: _SinkType = Field(...)
     level: str | int | None = Field(default=None)
-    format_: (
-        str | Callable[["Record"], str] | Callable[[dict[str, Any]], str] | None
-    ) = Field(default=None, validation_alias="format", serialization_alias="format")
-    filter_: (
-        Callable[["Record"], bool]
-        | Callable[[dict[str, Any]], bool]
-        | str
-        | dict[str, Any]
-        | None
-    ) = Field(default=None, validation_alias="filter", serialization_alias="filter")
+    format_: FormatType = Field(
+        default=None, validation_alias="format", serialization_alias="format"
+    )
+    filter_: _FilterType = Field(
+        default=None, validation_alias="filter", serialization_alias="filter"
+    )
     colorize: bool | None = Field(default=None)
     serialize: bool | None = Field(default=None)
     backtrace: bool | None = Field(default=None)
@@ -74,19 +101,8 @@ class LoguruHandlerPM(ExtraBaseModel):
     context: BaseContext | str | None = Field(default=None)
     catch: bool | None = Field(default=None)
     loop: AbstractEventLoop | None = Field(default=None)
-    rotation: (
-        str
-        | int
-        | datetime.time
-        | datetime.timedelta
-        | Callable[["Message", TextIO], bool]
-        | Callable[[str, TextIO], bool]
-        | Callable[[str, Any], bool]
-        | None
-    ) = Field(default=None)
-    retention: str | int | datetime.timedelta | Callable[[Any], None] | None = Field(
-        default=None
-    )
+    rotation: _RotationType = Field(default=None)
+    retention: _RetentionType = Field(default=None)
     compression: str | Callable[[str], None] | None = Field(default=None)
     delay: bool | None = Field(default=None)
     watch: bool | None = Field(default=None)
@@ -138,4 +154,5 @@ __all__ = [
     "ExtraBaseModel",
     "LoguruHandlerPM",
     "LogHandlerPM",
+    "FormatType",
 ]

--- a/templates/configs/logger.yml
+++ b/templates/configs/logger.yml
@@ -18,9 +18,9 @@ logger:
     include_modules: []
     mute_modules: []
   global_extra:
-    trace_id: "-"
-    request_id: "-"
-    user_id: "-"
+    trace_id: ""
+    request_id: ""
+    user_id: ""
   handlers:
     std_handler:
       enabled: true


### PR DESCRIPTION
Change global_extra fields in logger configuration from default values of "-" to empty strings for better clarity and consistency. Adjust related type definitions accordingly.