### PR TITLE
Upgrade dependencies for GitHub Actions and Python

### DIFF
--- a/.github/workflows/1.bump-version.yml
+++ b/.github/workflows/1.bump-version.yml
@@ -17,7 +17,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Bump version
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/2.build-publish.yml
+++ b/.github/workflows/2.build-publish.yml
@@ -17,7 +17,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
@@ -37,7 +37,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Get latest version
         run: |
           git pull origin main

--- a/.github/workflows/3.update-changelog.yml
+++ b/.github/workflows/3.update-changelog.yml
@@ -14,7 +14,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Update changelog
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -17,7 +17,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - name: Set up Python

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -113,7 +113,7 @@ repos:
 
   # --- Markdown ---
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.48.0
+    rev: v0.49.0
     hooks:
       - id: markdownlint
         name: "📝 markdownlint - Lint markdown files"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 pydantic[timezone]>=2.5.3,<3.0.0
 loguru>=0.7.3,<1.0.0
-potato_util>=0.10.0,<1.0.0
+potato_util>=0.11.0,<1.0.0


### PR DESCRIPTION
This pull request focuses on keeping the project dependencies up to date by upgrading the versions of key tools used in CI workflows and pre-commit hooks. The main changes are version bumps for the GitHub Actions `checkout` action and the `markdownlint-cli` tool.

**CI/CD workflow upgrades:**

* Updated all references to the `actions/checkout` action from version `v6` to `v7` across the following workflow files to ensure compatibility and receive the latest improvements and security patches:
  - `.github/workflows/1.bump-version.yml`
  - `.github/workflows/2.build-publish.yml` [[1]](diffhunk://#diff-c06acd67a77a30e433d009852aa65d7eadc0d0d86dca6ad99d9a5b1a764b0ce7L20-R20) [[2]](diffhunk://#diff-c06acd67a77a30e433d009852aa65d7eadc0d0d86dca6ad99d9a5b1a764b0ce7L40-R40)
  - `.github/workflows/3.update-changelog.yml`
  - `.github/workflows/publish-docs.yml`

**Pre-commit hook update:**

* Upgraded `markdownlint-cli` in `.pre-commit-config.yaml` from `v0.48.0` to `v0.49.0` to use the latest features and bug fixes.